### PR TITLE
Fix bugs in edge case scenarios

### DIFF
--- a/lib/rules/sort-requires.js
+++ b/lib/rules/sort-requires.js
@@ -1,14 +1,40 @@
 const buildSortRule = require('../utils/sort-rule-builder');
 
+const getCallExpression = node => {
+  if (!node) {
+    return null;
+  }
+
+  // If it's a MemberExpression keep recursing..
+  // require('foo').foo.bar
+  if (node.type === 'MemberExpression') {
+    return getCallExpression(node.object);
+  }
+
+  // If it's a CallExpression keep recursing, but return itself in case there's no child CallExpression.
+  // require('foo')('foo')('bar')
+  if (node.type === 'CallExpression') {
+    return getCallExpression(node.callee) ?? node;
+  }
+
+  return null;
+};
+
 const isTopLevel = node => node.parent.type === 'Program';
 
-const isStaticRequire = node =>
-  node.type === 'CallExpression' &&
-  node.callee.type === 'Identifier' &&
-  node.callee.name === 'require' &&
-  node.arguments.length === 1;
+const isRequireCallExpression = node => {
+  const callExpression = getCallExpression(node);
 
-const isRequire = node => node.type === 'VariableDeclaration' && node.declarations[0].init?.callee?.name === 'require';
+  return (
+    !!callExpression &&
+    callExpression.callee.type === 'Identifier' &&
+    callExpression.callee.name === 'require' &&
+    callExpression.arguments.length === 1
+  );
+};
+
+const isRequireVariableDeclaration = node =>
+  node.type === 'VariableDeclaration' && isRequireCallExpression(node.declarations[0].init);
 
 const hasVariableDeclarations = node => !!node.declarations;
 
@@ -27,7 +53,9 @@ const getMemberName = (node, options) => {
     return node.key.name;
   }
 
-  return node.value.name;
+  // Return value.name, falling back to key.name.
+  // value.name is undefined in case of nested destructuring, like const { x: { y } } = require('foo')
+  return node.value.name ?? node.key.name;
 };
 
 const getMemberSyntax = (node, options) => {
@@ -78,14 +106,14 @@ module.exports = buildSortRule(
   },
   processNode => ({
     ExpressionStatement: node => {
-      if (!isTopLevel(node) || !isStaticRequire(node.expression)) {
+      if (!isTopLevel(node) || !isRequireCallExpression(node.expression)) {
         return;
       }
 
       processNode(node);
     },
     VariableDeclaration: node => {
-      if (!isTopLevel(node) || !isRequire(node)) {
+      if (!isTopLevel(node) || !isRequireVariableDeclaration(node)) {
         return;
       }
 

--- a/tests/sort-requires.js
+++ b/tests/sort-requires.js
@@ -73,6 +73,46 @@ ruleTester.run('sort', rule, {
         }
       ]
     },
+    {
+      // Case require('foo').foo and const { x } = require('foo').foo
+      code: `
+        const { x } = require('foo').foo;
+        require('foo').foo.bar;
+      `,
+      errors: [
+        {
+          message: "Expected require declaration of 'none' syntax to be placed before 'single' syntax.",
+          type: 'ExpressionStatement'
+        }
+      ]
+    },
+    {
+      // Case require('foo')('foo') and const { x } = require('foo')('foo')
+      code: `
+        const { x } = require('foo')('foo').bar;
+        require('foo')('foo').bar;
+      `,
+      errors: [
+        {
+          message: "Expected require declaration of 'none' syntax to be placed before 'single' syntax.",
+          type: 'ExpressionStatement'
+        }
+      ]
+    },
+    {
+      // Case with nested destructuring..
+      code: `
+        const { foo } = require('foo');
+        const { bar: { ZZ } } = require('bar');
+        const { baz } = require('baz');
+      `,
+      errors: [
+        {
+          message: "Expected require declaration of 'bar' to be placed before 'foo'.",
+          type: 'VariableDeclaration'
+        }
+      ]
+    },
     // Declaration sort - default options with `unsafeAutofix`
     {
       code: `


### PR DESCRIPTION
Usage of `require('foo').foo`, `require('foo')('foo')` and nested destructuring.